### PR TITLE
Don't override H4

### DIFF
--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -388,7 +388,7 @@ html, body {
     margin-bottom: 0.8em;
   }
 
-  h4, h5, h6 {
+  h5, h6 {
     font-size: 10px;
   }
 


### PR DESCRIPTION
Using `h4` at 10px font size looks a tad ridiculous (see pic). Bump it back up to 15px like `h3`. W/ this change we have a good alternative to `h3` which adds a section to the left nav, which you might not want.

![image](https://user-images.githubusercontent.com/48697077/97607881-f7c5b080-19e7-11eb-807c-61bff74891ac.png)
